### PR TITLE
Update neotoma link to v2 api

### DIFF
--- a/src/Services/Core/GlobalPollenProject.Persistence/ReadModels.fs
+++ b/src/Services/Core/GlobalPollenProject.Persistence/ReadModels.fs
@@ -57,8 +57,10 @@ type EncyclopediaOfLifeCache = {
     CommonEnglishName:      string
     PhotoUrl:               string
     PhotoAttribution:       string
+    PhotoLicence:           string
     Description:            string
     DescriptionAttribution: string
+    DescriptionLicence:     string
     Retrieved:              DateTime
 }
 

--- a/src/Services/Core/GlobalPollenProject.Persistence/Serialisation.fs
+++ b/src/Services/Core/GlobalPollenProject.Persistence/Serialisation.fs
@@ -20,7 +20,6 @@ let serialiseEventToBytes (e:'a) =
     case.Name, json
 
 let inline deserialiseEventFromBytes< ^E> eventType (data:byte[]) =
-    printfn "De-serialising a domain event of type: %s" typeof< ^E>.FullName
     use stream = new System.IO.MemoryStream(data)
     try BackwardCompatible.deserializeStream< ^E> stream
     with

--- a/src/Web/WebUI/GlobalPollenProject.Web/Scripts/Components/distribution-map.ts
+++ b/src/Web/WebUI/GlobalPollenProject.Web/Scripts/Components/distribution-map.ts
@@ -11,19 +11,6 @@ const mapBoxAccessToken = "pk.eyJ1IjoibWFyZWVwMjAwMCIsImEiOiJjaWppeGUxdm8wMDQ3dm
 
 export function activate(container: HTMLElement) {
     $(() => {
-        const gbifId = $('#GbifId').val();
-        if (gbifId != 0) {
-            gbifMap(gbifId);
-        } else {
-            console.warn("There was no GBIF ID present (in #GbifId")
-        }
-        const neotomaId = parseInt($('#NeotomaId').val() as string);
-        if (neotomaId) {
-            new PointDistributionMap(neotomaId);
-        } else {
-            console.warn("Neotoma ID was invalid")
-        }
-        
         // Toggle for palaeo versus modern map
         $("input[name=distribution]").on("change",e => {
             const selected = ($(e.currentTarget).val());
@@ -35,6 +22,21 @@ export function activate(container: HTMLElement) {
                 $('#modern').show();
             }
         });
+        const gbifId = $('#GbifId').val();
+        if (gbifId != 0) {
+            gbifMap(gbifId);
+        } else {
+            console.warn("There was no GBIF ID present (in #GbifId")
+        }
+        const neotomaId = parseInt($('#NeotomaId').val() as string);
+        if (neotomaId) {
+            new PointDistributionMap(neotomaId);
+            $("input[name=distribution][value='palaeo']").prop("checked",true);
+            $('#palaeo').show();
+            $('#modern').hide();
+        } else {
+            console.warn("Neotoma ID was invalid")
+        }
     })
 }
 
@@ -153,19 +155,19 @@ class PointDistributionMap {
             }
         }).done(data => { this.neotomaCallback(data); })
     }
-    
+
     neotomaCallback(result) {
         this.points = [];
-        for (let i = 0; i < result.Occurrences.length; i++) {
+        for (let i = 0; i < result.occurrences.length; i++) {
             const coordinate = {
-                east: result.Occurrences[i].Longitude,
-                north: result.Occurrences[i].Latitude,
-                youngest: result.Occurrences[i].AgeYoungest,
-                oldest: result.Occurrences[i].AgeOldest
+                east: result.occurrences[i].longitude,
+                north: result.occurrences[i].latitude,
+                youngest: result.occurrences[i].ageYoungest,
+                oldest: result.occurrences[i].ageOldest
             };
             this.points.push(coordinate);
         }
-        //$('#palaeo-refresh-time').text("Data refreshed at ...")
+        $('#palaeo-refresh-time').text("Last retrieved " + result.refreshTime.substring(0,10) + ".");
         this.domPoints = this.svg.selectAll("circle").data(this.points).enter().append("circle").attr("cx", d => {
             return this.projection([d.east, d.north])[0];
         }).attr("cy", d => {

--- a/src/Web/WebUI/GlobalPollenProject.Web/View.fs
+++ b/src/Web/WebUI/GlobalPollenProject.Web/View.fs
@@ -712,7 +712,7 @@ module Taxon =
                         span [ _id "palaeo-range-low" ] []
                         str " to "
                         span [ _id "palaeo-range-high" ] []
-                        str " years before present."
+                        str " years before present. "
                         span [ _id "palaeo-refresh-time" ] []
                     ]
                     div [ _id "neotoma-map" ] []

--- a/src/Web/WebUI/GlobalPollenProject.Web/View.fs
+++ b/src/Web/WebUI/GlobalPollenProject.Web/View.fs
@@ -728,16 +728,17 @@ module Taxon =
                 div [ _class "card-fixed-height-image" ] [
                     img [ _src eolCache.PhotoUrl; _alt <| sprintf "%s (rights holder: %s)"latinName eolCache.PhotoAttribution ]
                     if not <| String.IsNullOrEmpty eolCache.PhotoAttribution then
-                        span [ _class "image-attribution" ] [ str <| "&copy " + eolCache.PhotoAttribution ]
+                        span [ _class "image-attribution" ] [ rawText "© " ; str eolCache.PhotoAttribution; str " "; a [ _href eolCache.PhotoLicence; _target "blank" ] [ str "(licence)"] ]
                 ]
             div [ _class "card-block" ] [
                 if String.IsNullOrEmpty eolCache.CommonEnglishName
                 then h4 [ _class "card-title" ] [ str latinName ]
                 else h4 [ _class "card-title" ] [ str eolCache.CommonEnglishName ]
                 if String.IsNullOrEmpty eolCache.Description |> not
-                then p [ _class "card-text" ] [ rawText (if eolCache.Description.Length > 400
-                                                         then eolCache.Description.Substring(0,400)
-                                                         else eolCache.Description) ]
+                then p [ _class "card-text" ] [ encodedText (if eolCache.Description.Length > 400
+                                                             then eolCache.Description.Substring(0,400) + "... "
+                                                             else eolCache.Description + " ")
+                                                em [] [ rawText "© "; str eolCache.DescriptionAttribution; str " "; a [ _href eolCache.DescriptionLicence; _target "blank" ] [ str ("(licence)") ] ] ]
                 a [ _class "card-link"; _href <| sprintf "http://eol.org/pages/%i/overview" eolId; _target "blank" ]
                     [ str "See more in the Encyclopedia of Life..." ]
             ]

--- a/test/core/GlobalPollenProject.Persistence.Tests/Serialisation.fs
+++ b/test/core/GlobalPollenProject.Persistence.Tests/Serialisation.fs
@@ -91,8 +91,10 @@ module ``When serialising read models`` =
                     { CommonEnglishName =      "Daisies"
                       PhotoUrl =               "https://somecoolurl.cool/cool.png"
                       PhotoAttribution =       "Daisy McDaisy"
+                      PhotoLicence =           "http://creativecommons.org/licenses/by-sa/3.0/"
                       Description =            "Daisies are common throughout the world."
                       DescriptionAttribution = "Daisy McDaisy"
+                      DescriptionLicence =     "http://creativecommons.org/licenses/by-sa/3.0/"
                       Retrieved =              DateTime()
             }
             BackboneChildren = 2 }


### PR DESCRIPTION
Restructures link to neotoma from v1 api (that is being retired) to their v2 api. Addresses #14 

Currently is limited to 10,000 occurrences per taxon - need to implement paging on our side to overcome this.
Also need to limit the rate of our requests, as their dataset is getting very large and don't want to burden their servers.