### PR TITLE
Use FSharpLu legacy serialise function

### DIFF
--- a/src/Services/Core/GlobalPollenProject.Persistence/Serialisation.fs
+++ b/src/Services/Core/GlobalPollenProject.Persistence/Serialisation.fs
@@ -5,26 +5,26 @@ open Microsoft.FSharpLu.Json
 open GlobalPollenProject.Core.Aggregates
 
 let serialise (o:'a) = 
-    try Compact.serialize o |> Ok
+    try Compact.Legacy.serialize o |> Ok
     with
     | _ -> Error "Could not serialise record"
 
 let inline deserialise< ^T> json = 
-    try BackwardCompatible.deserialize< ^T> json |> Ok
+    try Compact.Legacy.deserialize< ^T> json |> Ok
     with 
     | _ -> Error "Could not deserialise JSON"
 
 let serialiseEventToBytes (e:'a) =
     let case,_ = FSharpValue.GetUnionFields(e, typeof<'a>)
-    let json = Compact.serialize e |> System.Text.Encoding.UTF8.GetBytes
+    let json = Compact.Legacy.serialize e |> System.Text.Encoding.UTF8.GetBytes
     case.Name, json
 
 let inline deserialiseEventFromBytes< ^E> eventType (data:byte[]) =
     use stream = new System.IO.MemoryStream(data)
-    try BackwardCompatible.deserializeStream< ^E> stream
+    try Compact.Legacy.deserializeStream< ^E> stream
     with
-    | _ -> 
-        invalidOp (sprintf "There was a fatal problem when deserialising an event (%s)" eventType)
+    | e -> 
+        invalidOp (sprintf "There was a fatal problem when deserialising an event (%s). The error was: %s" eventType e.Message)
 
 let fromString<'a> (s:string) =
     match FSharpType.GetUnionCases typeof<'a> |> Array.filter (fun case -> case.Name = s) with


### PR DESCRIPTION
- Fixes bug deserialising existing Taxonomy events from the eventstore, by replacing the serialisation method with FSharpLu's legacy implementation (that we have previously used). See #30